### PR TITLE
Add auto-detection for local vs production API

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -567,9 +567,23 @@
 
     <!-- Config: set API_URL before loading main script -->
     <script>
-        // For production, replace this URL with your Cloud Run backend URL
-        // Or set window.API_URL in a separate config.js file
-        window.API_URL = window.API_URL || 'https://uk-autumn-budget-lifecycle-578039519715.europe-west1.run.app';
+        // Auto-detect local development vs production
+        // Use ?local=1 in URL to force localhost, or ?local=0 to force production
+        const urlParams = new URLSearchParams(window.location.search);
+        const forceLocal = urlParams.get('local');
+        const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+
+        const PROD_API = 'https://uk-autumn-budget-lifecycle-578039519715.europe-west1.run.app';
+        const LOCAL_API = 'http://localhost:8000';
+
+        if (forceLocal === '1') {
+            window.API_URL = LOCAL_API;
+        } else if (forceLocal === '0') {
+            window.API_URL = PROD_API;
+        } else {
+            // Default: use localhost when running locally, production otherwise
+            window.API_URL = window.API_URL || (isLocalhost ? LOCAL_API : PROD_API);
+        }
     </script>
     <script>
         const API_URL = window.API_URL;


### PR DESCRIPTION
## Summary

Adds automatic API URL detection to simplify local development.

### How it works

- **On localhost**: Automatically uses `http://localhost:8000`
- **On production (Vercel, etc.)**: Automatically uses the Cloud Run API

### URL parameter override

You can force a specific API using URL parameters:
- `?local=1` - Force localhost API (even on production)
- `?local=0` - Force production API (even on localhost)

This is useful for testing production API locally or debugging.

## Test plan

- [ ] Open `frontend/index.html` locally - should use localhost:8000
- [ ] Deploy to Vercel preview - should use Cloud Run API
- [ ] Test `?local=1` parameter forces localhost
- [ ] Test `?local=0` parameter forces production

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)