### PR TITLE
Add caveats section to methodology

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -607,6 +607,14 @@
                 <li>Unearned income (dividends, savings interest, property income) grows with CPI to maintain real value.</li>
                 <li>Positive values (green) indicate the reform makes you better off; negative (red) means worse off.</li>
             </ul>
+
+            <h3>Caveats</h3>
+            <ul>
+                <li><strong>Policies not modelled</strong> — Several Autumn Budget measures are not included in this tool, such as the two-child benefit limit repeal, changes to inheritance tax, employer NICs increases (which may affect wages indirectly), and various business tax changes. The model currently assumes a childless individual.</li>
+                <li><strong>Policy interactions</strong> — Each reform is modelled independently. In practice, some policies may interact in ways not fully captured (e.g., threshold freezes affecting multiple taxes simultaneously, or behavioural responses to policy changes).</li>
+                <li><strong>Simplified calculations</strong> — This is a stylised model using representative assumptions. Individual circumstances will vary significantly based on actual career paths, location, housing costs, family composition, and financial decisions.</li>
+                <li><strong>Long-term projections</strong> — Forecasts extending decades into the future are inherently uncertain. Actual policy, inflation, and earnings paths will differ from OBR projections.</li>
+            </ul>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
Add a "Caveats" section to the methodology documentation that clarifies:

- **Policies not modelled** — Two-child benefit limit repeal, inheritance tax changes, employer NICs increases, and other business tax changes. Notes the model assumes a childless individual.
- **Policy interactions** — Each reform is modelled independently; interactions may not be fully captured
- **Simplified calculations** — Individual circumstances vary significantly
- **Long-term projections** — Inherent uncertainty in multi-decade forecasts

## Test plan
- [ ] Verify caveats section renders correctly below assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)