### PR TITLE
Fix modal threshold freeze calculation using mismatched nominal/real values

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -813,12 +813,18 @@
             return currentData.map(row => {
                 const deflator = getCumulativeInflation(row.year);
                 const adjusted = { ...row };
-                // Deflate all monetary values
+                // Deflate all monetary values for chart display
                 reforms.forEach(r => {
                     adjusted[r.key] = row[r.key] / deflator;
                 });
                 adjusted.gross_income = row.gross_income / deflator;
                 adjusted.baseline_net_income = row.baseline_net_income / deflator;
+                adjusted.income_tax = row.income_tax / deflator;
+                adjusted.national_insurance = row.national_insurance / deflator;
+                adjusted.student_loan_payment = row.student_loan_payment / deflator;
+                adjusted.student_loan_debt_remaining = row.student_loan_debt_remaining / deflator;
+                // Note: threshold parameters (baseline_pa, reform_pa, etc.) are NOT deflated here
+                // Modal calculations use raw nominal values and apply toRealTerms() for display
                 return adjusted;
             });
         }
@@ -1420,10 +1426,11 @@
         }
 
         function renderTaxDetailChart(selectedAge) {
-            const data = getDisplayData();
-            if (!data.length) return;
+            // Use currentData (nominal values) for consistent tax calculations
+            // Then apply toRealTerms() only for display purposes
+            if (!currentData.length) return;
 
-            const row = data.find(d => d.age === selectedAge);
+            const row = currentData.find(d => d.age === selectedAge);
             const deflator = getCumulativeInflation(row?.year || 2026);
             if (!row || row.gross_income === 0) {
                 document.getElementById('tax-detail-chart').innerHTML = '<div style="text-align: center; color: #64748b; padding: 40px;">No income at this age (retired)</div>';
@@ -2470,10 +2477,11 @@
 
         // Container-based render functions for modal
         function renderTaxDetailChartToContainer(selectedAge, container) {
-            const data = getDisplayData();
-            if (!data.length) return;
+            // Use currentData (nominal values) for consistent tax calculations
+            // Then apply toRealTerms() only for display purposes
+            if (!currentData.length) return;
 
-            const row = data.find(d => d.age === selectedAge);
+            const row = currentData.find(d => d.age === selectedAge);
             if (!row || row.gross_income === 0) {
                 container.innerHTML = '<div style="text-align: center; color: #64748b; padding: 40px;">No income at this age (retired)</div>';
                 return;


### PR DESCRIPTION
## Summary
- Fixes mismatch between hover tooltip (-£478) and modal (+£68) for threshold freeze impact
- The modal was using deflated income but non-deflated thresholds, causing incorrect tax calculations
- Now uses nominal values (currentData) for calculations, with toRealTerms() applied only for display

## Root cause
When "Show in 2025 £" mode is enabled:
1. `getDisplayData()` deflated `gross_income` but NOT threshold parameters (`baseline_pa`, etc.)
2. Modal tax calculation used deflated income (~£11k in 2025 terms) against nominal thresholds
3. This produced incorrect results that didn't match the backend's authoritative calculation

## Fix
- `renderTaxDetailChart()` and `renderTaxDetailChartToContainer()` now use `currentData` directly
- All calculations use nominal values consistently
- `toRealTerms()` is applied only for display purposes

## Test plan
- [ ] Verify hover tooltip and modal "Total income tax" difference now match
- [ ] Check values in both nominal and real terms modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)