### PR TITLE
Format student loan debt slider as £45,000 instead of £45k

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -537,7 +537,7 @@
                     <label title="Initial debt at graduation. Evolves based on interest and repayments.">Student loan debt</label>
                     <div class="slider-container">
                         <input type="range" id="student_loan_debt" value="45000" min="0" max="100000" step="5000">
-                        <span class="slider-value" id="student_loan_debt_value">£45k</span>
+                        <span class="slider-value" id="student_loan_debt_value">£45,000</span>
                     </div>
                 </div>
 
@@ -840,9 +840,6 @@
             const v = parseFloat(value);
             if (id === 'current_age' || id === 'retirement_age' || id === 'life_expectancy') {
                 return v.toString();
-            }
-            if (id === 'student_loan_debt') {
-                return `£${Math.round(v / 1000)}k`;
             }
             return `£${d3.format(',.0f')(v)}`;
         }


### PR DESCRIPTION
## Summary
- Formats student loan debt slider value as £45,000 instead of £45k
- Consistent with other currency sliders which use full format

## Test plan
- [ ] Verify slider displays £45,000 on page load
- [ ] Verify slider updates correctly when moved (e.g., £50,000, £100,000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)